### PR TITLE
Add if __name__ block exit via SystemExit

### DIFF
--- a/app.py
+++ b/app.py
@@ -126,4 +126,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
explicit exit codes and makes it clear it’s a CLI entrypoint.