### PR TITLE
Explicitly specify UTF-8 encoding note in docstring

### DIFF
--- a/compare_styles.py
+++ b/compare_styles.py
@@ -1,3 +1,12 @@
+"""
+compare_styles.py
+
+Companion CLI for web3_style_sniffer.
+
+Compare your privacy/soundness needs against all configured styles and
+see which one fits best. Outputs UTF-8 text by default.
+"""
+
 import argparse
 import json
 from typing import List, Dict


### PR DESCRIPTION
Helpful if someone runs on weird locales.